### PR TITLE
Fix Rims not loading when Custom is selected in visualizer.

### DIFF
--- a/WalkmeshVisualizerWpf/Views/VisualizerWindow.xaml.cs
+++ b/WalkmeshVisualizerWpf/Views/VisualizerWindow.xaml.cs
@@ -992,11 +992,13 @@ namespace WalkmeshVisualizerWpf.Views
                 if (exe.Name.ToLower() == "swkotor.exe")
                 {
                     CurrentGame = XmlGameData.Kotor1Data;
+                    RimDataSet.LoadGameData(dir.FullName);
                     LoadGameFiles(dir.FullName, K1_NAME);
                 }
                 if (exe.Name.ToLower() == "swkotor2.exe")
                 {
                     CurrentGame = XmlGameData.Kotor2Data;
+                    RimDataSet.LoadGameData(dir.FullName);
                     LoadGameFiles(dir.FullName, K2_NAME);
                 }
             }


### PR DESCRIPTION
When using "Custom" as the selection, Rims are never loaded, causing a sequence error after selecting the module in the menu.  Testing this change on my machine allowed it to work.
Use case: I install my games to a second drive instead of the default drive.