### PR TITLE
Distance calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The walkmesh visualization projects were created by Glasnonck. This solution use
       </ul>
     </td>
   </tr>
+
   <tr><td colspan="2" align="center"><b id="modules">Gather Party Info</b></td></tr>
   <tr>
     <td align="center">
@@ -53,6 +54,7 @@ The walkmesh visualization projects were created by Glasnonck. This solution use
       </ul>
     </td>
   </tr>
+
   <tr><td colspan="2" align="center"><b id="items">Compare Modules</b></td></tr>
   <tr>
     <td align="center">
@@ -68,6 +70,7 @@ The walkmesh visualization projects were created by Glasnonck. This solution use
       </ul>
     </td>
   </tr>
+
   <tr><td colspan="2" align="center"><b id="items">View Triggers and Doors</b></td></tr>
   <tr>
     <td align="center">
@@ -81,6 +84,41 @@ The walkmesh visualization projects were created by Glasnonck. This solution use
         <li>Triggers and encounters display their entire geometry, allowing you to find gaps or route around them.</li>
         <li>Encounters also display the spawn point for enemies created by the encounter.</li>
         <li>A toggle button will display DLZ lines from each corner. This allows you to see where is possible to perform the <a href="https://kotor-speedruns.github.io/kotor1/Major%20Glitches/Displaced%20Load%20Zone">Displaced Loading Zone</a> glitch, which activates the trigger when your position matches exactly.</li>
+      </ul>
+    </td>
+  </tr>
+
+  <tr><td colspan="2" align="center"><b id="items">View Live Position</b></td></tr>
+  <tr>
+    <td align="center">
+    </td>
+    <td>
+      <ul>
+        <li>View live position and bearing of each party member.</li>
+      </ul>
+    </td>
+  </tr>
+
+  <tr><td colspan="2" align="center"><b id="items">View Gather Party Distance</b></td></tr>
+  <tr>
+    <td align="center">
+    </td>
+    <td>
+      <ul>
+        <li>View the maximum distance party members can be from the Leader when traveling through loading zones. The highlighted area will display as Green when party members are in range and red when they are out of range.</li>
+        <li>This range can be displayed either from the live Leader position or one of the double click coordinates.</li>
+        <li>The live Leader position GP range can be locked in place temporarily to assist when testing with no party members.</li>
+      </ul>
+    </td>
+  </tr>
+
+  <tr><td colspan="2" align="center"><b id="items">Distance and Real-Time Calculation</b></td></tr>
+  <tr>
+    <td align="center">
+    </td>
+    <td>
+      <ul>
+        <li>Distance can be calculated between double click points and live Leader position. The distance is displayed as both in-game units and the time it takes to travel that distance when running without buffs or with alacrity, hyper-alacrity, or force speed.</li>
       </ul>
     </td>
   </tr>

--- a/README.md
+++ b/README.md
@@ -95,6 +95,8 @@ The walkmesh visualization projects were created by Glasnonck. This solution use
     <td>
       <ul>
         <li>View live position and bearing of each party member.</li>
+        <li>Automatically load the walkmesh for the current level in-game, and automatically swap to a new walkmesh when entering a new level.</li>
+        <li>Automatically detect which game is running and load the walkmesh data for that game.</li>
       </ul>
     </td>
   </tr>
@@ -118,7 +120,9 @@ The walkmesh visualization projects were created by Glasnonck. This solution use
     </td>
     <td>
       <ul>
-        <li>Distance can be calculated between double click points and live Leader position. The distance is displayed as both in-game units and the time it takes to travel that distance when running without buffs or with alacrity, hyper-alacrity, or force speed.</li>
+        <li>In-game distance can be calculated and displayed in both in-game units and the time it takes to travel that distance when running without buffs or with alacrity, hyper-alacrity, or force speed.</li>
+        <li>Distance can calculated between double click points and the live Leader position.</li>
+        <li>Distance can calculated as a single line segment or as a path of line segments. Up to three paths can be compared at the same time.</li>
       </ul>
     </td>
   </tr>

--- a/WalkmeshVisualizerWpf/App.config
+++ b/WalkmeshVisualizerWpf/App.config
@@ -88,6 +88,9 @@
             <setting name="ShowLeftClickGatherPartyRange" serializeAs="String">
                 <value>False</value>
             </setting>
+            <setting name="ShowDistancePanel" serializeAs="String">
+                <value>False</value>
+            </setting>
         </WalkmeshVisualizerWpf.Properties.Settings>
     </userSettings>
 </configuration>

--- a/WalkmeshVisualizerWpf/Helpers/MouseHandlingMode.cs
+++ b/WalkmeshVisualizerWpf/Helpers/MouseHandlingMode.cs
@@ -26,6 +26,11 @@ namespace WalkmeshVisualizerWpf.Helpers
         Panning,
 
         /// <summary>
+        /// The user is right-mouse-button-dragging a line segment.
+        /// </summary>
+        DrawingLine,
+
+        /// <summary>
         /// The user is holding down shift and left-clicking or right-clicking to zoom in or out.
         /// </summary>
         Zooming,

--- a/WalkmeshVisualizerWpf/Properties/Settings.Designer.cs
+++ b/WalkmeshVisualizerWpf/Properties/Settings.Designer.cs
@@ -334,5 +334,17 @@ namespace WalkmeshVisualizerWpf.Properties {
                 this["ShowLeftClickGatherPartyRange"] = value;
             }
         }
+        
+        [global::System.Configuration.UserScopedSettingAttribute()]
+        [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
+        [global::System.Configuration.DefaultSettingValueAttribute("False")]
+        public bool ShowDistancePanel {
+            get {
+                return ((bool)(this["ShowDistancePanel"]));
+            }
+            set {
+                this["ShowDistancePanel"] = value;
+            }
+        }
     }
 }

--- a/WalkmeshVisualizerWpf/Properties/Settings.settings
+++ b/WalkmeshVisualizerWpf/Properties/Settings.settings
@@ -80,5 +80,8 @@
     <Setting Name="ShowLeftClickGatherPartyRange" Type="System.Boolean" Scope="User">
       <Value Profile="(Default)">False</Value>
     </Setting>
+    <Setting Name="ShowDistancePanel" Type="System.Boolean" Scope="User">
+      <Value Profile="(Default)">False</Value>
+    </Setting>
   </Settings>
 </SettingsFile>

--- a/WalkmeshVisualizerWpf/Views/VisualizerWindow.xaml
+++ b/WalkmeshVisualizerWpf/Views/VisualizerWindow.xaml
@@ -1707,6 +1707,34 @@
                                 <Setter Property="Stroke" Value="Black" />
                                 <Setter Property="Margin" Value="0,0,0,0" />
                             </Style>
+                            <Style TargetType="Button" x:Key="styleClearPathButton">
+                                <Setter Property="Content" Value="X" />
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                                <Setter Property="FontSize" Value="8" />
+                                <Setter Property="Padding" Value="3,0" />
+                                <Setter Property="Margin" Value="0,0,8,0" />
+                                <Setter Property="Width" Value="13" />
+                                <EventSetter Event="Click" Handler="ClearPathButton_Click" />
+                            </Style>
+                            <Style TargetType="Button" x:Key="styleAddToPathButton">
+                                <Setter Property="Content" Value="+" />
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                                <Setter Property="FontSize" Value="10" />
+                                <Setter Property="Padding" Value="2,-3,2,1" />
+                                <Setter Property="Margin" Value="8,0,0,0" />
+                                <Setter Property="Width" Value="13" />
+                                <EventSetter Event="Click" Handler="AddToPathButton_Click" />
+                            </Style>
+                            <Style TargetType="Line" x:Key="styleSegmentIcon">
+                                <Setter Property="X1" Value="0" />
+                                <Setter Property="Y1" Value="0" />
+                                <Setter Property="X2" Value="14" />
+                                <Setter Property="Y2" Value="0" />
+                                <Setter Property="StrokeThickness" Value="3" />
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                                <Setter Property="StrokeEndLineCap" Value="Round" />
+                                <Setter Property="StrokeStartLineCap" Value="Round" />
+                            </Style>
                         </Grid.Resources>
 
                         <!-- Distance speed options -->
@@ -1754,23 +1782,23 @@
 
                                 <!-- Distance from Left Point to Right Point -->
                                 <StackPanel>
-                                    <Border>
+                                    <Border Margin="12,0,0,0">
                                         <StackPanel Orientation="Horizontal">
                                             <Ellipse Fill="Black" Margin="0,0,1,0" />
                                             <Ellipse Fill="White" />
                                         </StackPanel>
                                     </Border>
-                                    <TextBlock Text=" = " />
-                                    <TextBlock TextAlignment="Right" Width="36"
-                                           Text="{Binding DistanceLeftRight, StringFormat=N2, FallbackValue=4.20}" />
-                                    <TextBlock Text=", Time = " />
                                     <TextBlock TextAlignment="Right" Width="50"
-                                           Text="{Binding DurationLeftRight, StringFormat=N2, FallbackValue=333.33}" />
+                                           Text="{Binding DistanceLeftRight, StringFormat=N2, FallbackValue=1.11}" />
+                                    <TextBlock Text="m," />
+                                    <TextBlock TextAlignment="Right" Width="50"
+                                           Text="{Binding DurationLeftRight, StringFormat=N2, FallbackValue=1.11}" />
+                                    <TextBlock Text="s" />
                                 </StackPanel>
 
                                 <!-- Distance from Live to Left Point -->
                                 <StackPanel>
-                                    <Border>
+                                    <Border Margin="12,0,0,0">
                                         <StackPanel Orientation="Horizontal">
                                             <Grid Margin="0,0,1,0">
                                                 <Ellipse Stroke="Black" Fill="#4E6BDF" />
@@ -1781,17 +1809,17 @@
                                             <Ellipse Fill="Black" />
                                         </StackPanel>
                                     </Border>
-                                    <TextBlock Text=" = " />
-                                    <TextBlock TextAlignment="Right" Width="36"
+                                    <TextBlock TextAlignment="Right" Width="50"
                                            Text="{Binding DistanceLiveLeft, StringFormat=N2, FallbackValue=69.69}" />
-                                    <TextBlock Text=", Time = " />
+                                    <TextBlock Text="m," />
                                     <TextBlock TextAlignment="Right" Width="50"
                                            Text="{Binding DurationLiveLeft, StringFormat=N2, FallbackValue=333.33}" />
+                                    <TextBlock Text="s" />
                                 </StackPanel>
 
                                 <!-- Distance from Live to Right Point -->
                                 <StackPanel>
-                                    <Border>
+                                    <Border Margin="12,0,0,0">
                                         <StackPanel Orientation="Horizontal">
                                             <Grid Margin="0,0,1,0">
                                                 <Ellipse Stroke="Black" Fill="#4E6BDF" />
@@ -1802,12 +1830,79 @@
                                             <Ellipse Fill="White" />
                                         </StackPanel>
                                     </Border>
-                                    <TextBlock Text=" = " />
-                                    <TextBlock TextAlignment="Right" Width="36"
+                                    <TextBlock TextAlignment="Right" Width="50"
                                            Text="{Binding DistanceLiveRight, StringFormat=N2, FallbackValue=333.33}" />
-                                    <TextBlock Text=", Time = " />
+                                    <TextBlock Text="m," />
                                     <TextBlock TextAlignment="Right" Width="50"
                                            Text="{Binding DurationLiveRight, StringFormat=N2, FallbackValue=333.33}" />
+                                    <TextBlock Text="s" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                        
+                        <!-- Segment Distance -->
+                        <Border Grid.Row="2" Margin="0,0,0,4" Padding="4,0,4,6" BorderThickness="0,0,0,1" BorderBrush="#707070">
+                            <StackPanel Orientation="Vertical">
+                                <!-- Title -->
+                                <TextBlock HorizontalAlignment="Center" Text="Segment Distance" Margin="0,0,0,4" />
+
+                                <!-- Length of the segment -->
+                                <StackPanel Orientation="Horizontal" Margin="0">
+                                    <Button Style="{StaticResource styleClearPathButton}" Tag="Black" />
+                                    <Line Style="{StaticResource styleSegmentIcon}" Stroke="Black" />
+                                    <TextBlock TextAlignment="Right" Width="50"
+                                           Text="{Binding DistanceTempSegment, StringFormat=N2, FallbackValue=1.11}" />
+                                    <TextBlock Text="m," />
+                                    <TextBlock TextAlignment="Right" Width="50"
+                                           Text="{Binding DurationTempSegment, StringFormat=N2, FallbackValue=333.33}" />
+                                    <TextBlock Text="s" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                        
+                        <!-- Path Distances -->
+                        <Border Grid.Row="3" Margin="0,0,0,4" Padding="4,0,4,6" BorderThickness="0,0,0,1" BorderBrush="#707070">
+                            <StackPanel Orientation="Vertical">
+                                <!-- Title -->
+                                <TextBlock HorizontalAlignment="Center" Text="Path Distances" Margin="0,0,0,4" />
+
+                                <!-- Length of blue path -->
+                                <StackPanel Orientation="Horizontal" Margin="0">
+                                    <Button Style="{StaticResource styleClearPathButton}" Tag="Blue" />
+                                    <Line Style="{StaticResource styleSegmentIcon}" Stroke="Blue" />
+                                    <TextBlock TextAlignment="Right" Width="50"
+                                           Text="{Binding DistanceBluePath, StringFormat=N2, FallbackValue=1.11}" />
+                                    <TextBlock Text="m," />
+                                    <TextBlock TextAlignment="Right" Width="50"
+                                           Text="{Binding DurationBluePath, StringFormat=N2, FallbackValue=1.11}" />
+                                    <TextBlock Text="s" />
+                                    <Button Style="{StaticResource styleAddToPathButton}" Tag="Blue" />
+                                </StackPanel>
+                                
+                                <!-- Length of red path -->
+                                <StackPanel Orientation="Horizontal" Margin="0">
+                                    <Button Style="{StaticResource styleClearPathButton}" Tag="Red" />
+                                    <Line Style="{StaticResource styleSegmentIcon}" Stroke="Red" />
+                                    <TextBlock TextAlignment="Right" Width="50"
+                                           Text="{Binding DistanceRedPath, StringFormat=N2, FallbackValue=22.22}" />
+                                    <TextBlock Text="m," />
+                                    <TextBlock TextAlignment="Right" Width="50"
+                                           Text="{Binding DurationRedPath, StringFormat=N2, FallbackValue=22.22}" />
+                                    <TextBlock Text="s" />
+                                    <Button Style="{StaticResource styleAddToPathButton}" Tag="Red" />
+                                </StackPanel>
+                                
+                                <!-- Length of green path -->
+                                <StackPanel Orientation="Horizontal" Margin="0">
+                                    <Button Style="{StaticResource styleClearPathButton}" Tag="Green" />
+                                    <Line Style="{StaticResource styleSegmentIcon}" Stroke="Green" />
+                                    <TextBlock TextAlignment="Right" Width="50"
+                                           Text="{Binding DistanceGreenPath, StringFormat=N2, FallbackValue=333.33}" />
+                                    <TextBlock Text="m," />
+                                    <TextBlock TextAlignment="Right" Width="50"
+                                           Text="{Binding DurationGreenPath, StringFormat=N2, FallbackValue=333.33}" />
+                                    <TextBlock Text="s" />
+                                    <Button Style="{StaticResource styleAddToPathButton}" Tag="Green" />
                                 </StackPanel>
                             </StackPanel>
                         </Border>
@@ -1897,6 +1992,19 @@
                                     <Style TargetType="TextBlock">
                                         <Setter Property="FontSize" Value="4" />
                                         <Setter Property="Foreground" Value="{Binding CoordinateTextBrush}" />
+                                    </Style>
+
+                                    <Style TargetType="Path">
+                                        <Setter Property="StrokeThickness" Value=".35" />
+                                        <Setter Property="StrokeStartLineCap" Value="Round" />
+                                        <Setter Property="StrokeEndLineCap" Value="Round" />
+                                        <!--<Setter Property="StrokeLineJoin" Value="" />-->
+                                    </Style>
+
+                                    <Style TargetType="Line" x:Key="baseLine">
+                                        <Setter Property="StrokeThickness" Value=".35" />
+                                        <Setter Property="StrokeEndLineCap" Value="Round" />
+                                        <Setter Property="StrokeStartLineCap" Value="Round" />
                                     </Style>
                                 </Canvas.Resources>
 
@@ -2087,6 +2195,34 @@
                                         <TextBlock Text=")" />
                                     </StackPanel>
                                 </Border>
+
+                                <Path x:Name="tempSegment" Stroke="Black" Visibility="{Binding TempSegmentVisible, Converter={StaticResource BoolToVisibilityConverter}}">
+                                    <Path.Data>
+                                        <LineGeometry StartPoint="{Binding TempSegmentStart}" EndPoint="{Binding TempSegmentEnd, Mode=TwoWay}" />
+                                    </Path.Data>
+                                </Path>
+
+                                <Grid x:Name="BluePathGrid" Visibility="{Binding BluePathVisible, Converter={StaticResource BoolToVisibilityConverter}}">
+                                    <Grid.Resources>
+                                        <Style TargetType="Line" BasedOn="{StaticResource baseLine}">
+                                            <Setter Property="Stroke" Value="Blue" />
+                                        </Style>
+                                    </Grid.Resources>
+                                </Grid>
+                                <Grid x:Name="RedPathGrid" Visibility="{Binding RedPathVisible, Converter={StaticResource BoolToVisibilityConverter}}">
+                                    <Grid.Resources>
+                                        <Style TargetType="Line" BasedOn="{StaticResource baseLine}">
+                                            <Setter Property="Stroke" Value="Red" />
+                                        </Style>
+                                    </Grid.Resources>
+                                </Grid>
+                                <Grid x:Name="GreenPathGrid" Visibility="{Binding GreenPathVisible, Converter={StaticResource BoolToVisibilityConverter}}">
+                                    <Grid.Resources>
+                                        <Style TargetType="Line" BasedOn="{StaticResource baseLine}">
+                                            <Setter Property="Stroke" Value="Green" />
+                                        </Style>
+                                    </Grid.Resources>
+                                </Grid>
                             </Canvas>
 
                             <!--

--- a/WalkmeshVisualizerWpf/Views/VisualizerWindow.xaml
+++ b/WalkmeshVisualizerWpf/Views/VisualizerWindow.xaml
@@ -821,6 +821,31 @@
                     <Style TargetType="ListViewItem" x:Key="MatchItemStyle" BasedOn="{StaticResource BaseItemStyle}">
                         <EventSetter Event="MouseDoubleClick" Handler="MatchItem_DoubleClick" />
                     </Style>
+                    <Style TargetType="ToggleButton" x:Key="panelHorizontalToggleButton">
+                        <Setter Property="Background" Value="Transparent" />
+                        <Setter Property="BorderBrush" Value="#FF707070" />
+                        <Setter Property="BorderThickness" Value="0,0,0,4" />
+                        <Setter Property="Margin" Value="0,0,4,0" />
+                        <Setter Property="Height" Value="22" />
+                        <Setter Property="Template">
+                            <Setter.Value>
+                                <ControlTemplate TargetType="ToggleButton">
+                                    <Border Background="{TemplateBinding Background}" BorderThickness="{TemplateBinding BorderThickness}" BorderBrush="{TemplateBinding BorderBrush}">
+                                        <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center" />
+                                    </Border>
+                                </ControlTemplate>
+                            </Setter.Value>
+                        </Setter>
+                        <Style.Triggers>
+                            <Trigger Property="IsMouseOver" Value="True">
+                                <Setter Property="BorderBrush" Value="MediumSlateBlue" />
+                                <Setter Property="Background" Value="Lavender" />
+                            </Trigger>
+                            <Trigger Property="IsChecked" Value="True">
+                                <Setter Property="BorderBrush" Value="Indigo" />
+                            </Trigger>
+                        </Style.Triggers>
+                    </Style>
                     <Style TargetType="ToggleButton" x:Key="panelToggleButton">
                         <Setter Property="Background" Value="Transparent" />
                         <Setter Property="BorderBrush" Value="#FF707070" />
@@ -863,9 +888,14 @@
                                   Click="CoordinatePanelButton_Click"
                                   Style="{StaticResource panelToggleButton}"
                                   />
-                    <ToggleButton Content="RIM Data"
+                    <ToggleButton Content="RIM Triggers"
                                   IsChecked="{Binding ShowRimDataPanel}"
                                   Click="RimDataPanelButton_Click"
+                                  Style="{StaticResource panelToggleButton}"
+                                  />
+                    <ToggleButton Content="Distance"
+                                  IsChecked="{Binding ShowDistancePanel}"
+                                  Click="DistancePanelButton_Click"
                                   Style="{StaticResource panelToggleButton}"
                                   />
                 </StackPanel>
@@ -877,10 +907,6 @@
                       Visibility="{Binding ShowCoordinatePanel,
                             Converter={StaticResource BoolToVisibilityConverter},
                             FallbackValue=Collapsed, TargetNullValue=Collapsed}">
-                    <Grid.ColumnDefinitions>
-                        <ColumnDefinition Width="*" MinWidth="215" />
-                    </Grid.ColumnDefinitions>
-                    
                     <Grid Margin="4,0,0,0">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
@@ -1108,6 +1134,7 @@
                         <ColumnDefinition Width="*" />
                     </Grid.ColumnDefinitions>
                     
+                    <!-- Sub Tabs Buttons -->
                     <StackPanel Orientation="Vertical" Margin="2,0,0,0">
                         <ToggleButton IsChecked="{Binding ShowRimDataDoors}"
                                       Style="{StaticResource panelToggleButton}"
@@ -1659,6 +1686,135 @@
                 </Grid>
 
                 <!--
+                Left Panel: Distance Panel
+                -->
+                <Grid x:Name="distancePanel" Grid.Column="1"
+                      Visibility="{Binding ShowDistancePanel,
+                            Converter={StaticResource BoolToVisibilityConverter},
+                            FallbackValue=Visible, TargetNullValue=Collapsed}">
+                    <Grid Margin="4,0,0,0" Width="300">
+                        <Grid.RowDefinitions>
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="Auto" />
+                            <RowDefinition Height="*" />
+                        </Grid.RowDefinitions>
+                        <Grid.Resources>
+                            <Style TargetType="Ellipse">
+                                <Setter Property="Height" Value="12" />
+                                <Setter Property="Width" Value="12" />
+                                <Setter Property="Stroke" Value="Black" />
+                                <Setter Property="Margin" Value="0,0,0,0" />
+                            </Style>
+                        </Grid.Resources>
+
+                        <!-- Distance speed options -->
+                        <StackPanel HorizontalAlignment="Center" x:Name="distPanelSpeedButtons" Orientation="Horizontal">
+                            <StackPanel.Resources>
+                                <Style TargetType="TextBlock">
+                                    <Setter Property="Margin" Value="5,0" />
+                                </Style>
+                                <Style TargetType="ToggleButton" BasedOn="{StaticResource panelHorizontalToggleButton}">
+                                    <EventSetter Event="Click" Handler="DistanceSpeedButton_Click" />
+                                </Style>
+                            </StackPanel.Resources>
+                            <ToggleButton Tag="1.0" IsChecked="True">
+                                <TextBlock Text="Run" />
+                            </ToggleButton>
+                            <ToggleButton Tag="1.2">
+                                <TextBlock Text="Alacrity" />
+                            </ToggleButton>
+                            <ToggleButton Tag="1.3">
+                                <TextBlock Text="Hyper Alacrity" />
+                            </ToggleButton>
+                            <ToggleButton Tag="1.5">
+                                <TextBlock Text="Force Speed" />
+                            </ToggleButton>
+                        </StackPanel>
+
+                        <!-- Coordinate Distances -->
+                        <Border Grid.Row="1" Margin="0,4" Padding="4,2" BorderThickness="0,1" BorderBrush="#707070">
+                            <StackPanel Orientation="Vertical" Margin="0">
+                                <StackPanel.Resources>
+                                    <Style TargetType="StackPanel">
+                                        <Setter Property="Orientation" Value="Horizontal" />
+                                        <Setter Property="Margin" Value="0,0,0,4" />
+                                    </Style>
+                                    <Style TargetType="Border">
+                                        <Setter Property="BorderBrush" Value="Black" />
+                                        <Setter Property="BorderThickness" Value="0,1,0,0" />
+                                        <Setter Property="Padding" Value="0,1,0,0" />
+                                        <Setter Property="Margin" Value="0,0,2,0" />
+                                    </Style>
+                                </StackPanel.Resources>
+
+                                <!-- Title -->
+                                <TextBlock HorizontalAlignment="Center" Text="Coordinate Distances" Margin="0,0,0,4" />
+
+                                <!-- Distance from Left Point to Right Point -->
+                                <StackPanel>
+                                    <Border>
+                                        <StackPanel Orientation="Horizontal">
+                                            <Ellipse Fill="Black" Margin="0,0,1,0" />
+                                            <Ellipse Fill="White" />
+                                        </StackPanel>
+                                    </Border>
+                                    <TextBlock Text=" = " />
+                                    <TextBlock TextAlignment="Right" Width="36"
+                                           Text="{Binding DistanceLeftRight, StringFormat=N2, FallbackValue=4.20}" />
+                                    <TextBlock Text=", Time = " />
+                                    <TextBlock TextAlignment="Right" Width="50"
+                                           Text="{Binding DurationLeftRight, StringFormat=N2, FallbackValue=333.33}" />
+                                </StackPanel>
+
+                                <!-- Distance from Live to Left Point -->
+                                <StackPanel>
+                                    <Border>
+                                        <StackPanel Orientation="Horizontal">
+                                            <Grid Margin="0,0,1,0">
+                                                <Ellipse Stroke="Black" Fill="#4E6BDF" />
+                                                <Polygon Points="6,6 0,10 6,0 12,10"
+                                                     Stroke="Black" Fill="#42BFA4"
+                                                     StrokeLineJoin="Round" StrokeThickness=".5" />
+                                            </Grid>
+                                            <Ellipse Fill="Black" />
+                                        </StackPanel>
+                                    </Border>
+                                    <TextBlock Text=" = " />
+                                    <TextBlock TextAlignment="Right" Width="36"
+                                           Text="{Binding DistanceLiveLeft, StringFormat=N2, FallbackValue=69.69}" />
+                                    <TextBlock Text=", Time = " />
+                                    <TextBlock TextAlignment="Right" Width="50"
+                                           Text="{Binding DurationLiveLeft, StringFormat=N2, FallbackValue=333.33}" />
+                                </StackPanel>
+
+                                <!-- Distance from Live to Right Point -->
+                                <StackPanel>
+                                    <Border>
+                                        <StackPanel Orientation="Horizontal">
+                                            <Grid Margin="0,0,1,0">
+                                                <Ellipse Stroke="Black" Fill="#4E6BDF" />
+                                                <Polygon Points="6,6 0,10 6,0 12,10"
+                                                     Stroke="Black" Fill="#42BFA4"
+                                                     StrokeLineJoin="Round" StrokeThickness=".5" />
+                                            </Grid>
+                                            <Ellipse Fill="White" />
+                                        </StackPanel>
+                                    </Border>
+                                    <TextBlock Text=" = " />
+                                    <TextBlock TextAlignment="Right" Width="36"
+                                           Text="{Binding DistanceLiveRight, StringFormat=N2, FallbackValue=333.33}" />
+                                    <TextBlock Text=", Time = " />
+                                    <TextBlock TextAlignment="Right" Width="50"
+                                           Text="{Binding DurationLiveRight, StringFormat=N2, FallbackValue=333.33}" />
+                                </StackPanel>
+                            </StackPanel>
+                        </Border>
+                    </Grid>
+                </Grid>
+
+                <!--
                 Left Panel Grid Splitter
                 -->
                 <GridSplitter x:Name="gsLeftPanel" Grid.Column="2" Width="3" Background="#FF707070"
@@ -1669,6 +1825,7 @@
                                       FallbackValue="Collapsed" TargetNullValue="Collapsed">
                             <Binding Path="ShowCoordinatePanel" />
                             <Binding Path="ShowRimDataPanel" />
+                            <Binding Path="ShowDistancePanel" />
                         </MultiBinding>
                     </GridSplitter.Visibility>
                 </GridSplitter>

--- a/WalkmeshVisualizerWpf/Views/VisualizerWindow.xaml
+++ b/WalkmeshVisualizerWpf/Views/VisualizerWindow.xaml
@@ -825,7 +825,7 @@
                         <Setter Property="Background" Value="Transparent" />
                         <Setter Property="BorderBrush" Value="#FF707070" />
                         <Setter Property="BorderThickness" Value="0,0,0,4" />
-                        <Setter Property="Margin" Value="0,0,4,0" />
+                        <Setter Property="Margin" Value="0,0,3,0" />
                         <Setter Property="Height" Value="22" />
                         <Setter Property="Template">
                             <Setter.Value>
@@ -842,6 +842,8 @@
                                 <Setter Property="Background" Value="Lavender" />
                             </Trigger>
                             <Trigger Property="IsChecked" Value="True">
+                                <Setter Property="BorderThickness" Value="1,1,1,4" />
+                                <Setter Property="Margin" Value="-1,-1,2,0" />
                                 <Setter Property="BorderBrush" Value="Indigo" />
                             </Trigger>
                         </Style.Triggers>
@@ -1692,7 +1694,7 @@
                       Visibility="{Binding ShowDistancePanel,
                             Converter={StaticResource BoolToVisibilityConverter},
                             FallbackValue=Visible, TargetNullValue=Collapsed}">
-                    <Grid Margin="4,0,0,0" Width="300">
+                    <Grid Margin="4,0,0,0">
                         <Grid.RowDefinitions>
                             <RowDefinition Height="Auto" />
                             <RowDefinition Height="Auto" />
@@ -1716,12 +1718,21 @@
                                 <Setter Property="Width" Value="13" />
                                 <EventSetter Event="Click" Handler="ClearPathButton_Click" />
                             </Style>
+                            <Style TargetType="Button" x:Key="styleMinusPathButton">
+                                <Setter Property="Content" Value="–" />
+                                <Setter Property="VerticalAlignment" Value="Center" />
+                                <Setter Property="FontSize" Value="10" />
+                                <Setter Property="Padding" Value="2,-3,2,1" />
+                                <Setter Property="Margin" Value="8,0,0,0" />
+                                <Setter Property="Width" Value="13" />
+                                <EventSetter Event="Click" Handler="MinusPathButton_Click" />
+                            </Style>
                             <Style TargetType="Button" x:Key="styleAddToPathButton">
                                 <Setter Property="Content" Value="+" />
                                 <Setter Property="VerticalAlignment" Value="Center" />
                                 <Setter Property="FontSize" Value="10" />
                                 <Setter Property="Padding" Value="2,-3,2,1" />
-                                <Setter Property="Margin" Value="8,0,0,0" />
+                                <Setter Property="Margin" Value="4,0,0,0" />
                                 <Setter Property="Width" Value="13" />
                                 <EventSetter Event="Click" Handler="AddToPathButton_Click" />
                             </Style>
@@ -1738,12 +1749,13 @@
                         </Grid.Resources>
 
                         <!-- Distance speed options -->
-                        <StackPanel HorizontalAlignment="Center" x:Name="distPanelSpeedButtons" Orientation="Horizontal">
+                        <StackPanel HorizontalAlignment="Center" x:Name="distPanelSpeedButtons" Orientation="Horizontal" Margin="0,0,-3,0">
                             <StackPanel.Resources>
                                 <Style TargetType="TextBlock">
-                                    <Setter Property="Margin" Value="5,0" />
+                                    <Setter Property="Margin" Value="3,0" />
                                 </Style>
                                 <Style TargetType="ToggleButton" BasedOn="{StaticResource panelHorizontalToggleButton}">
+                                    <Setter Property="FontSize" Value="12" />
                                     <EventSetter Event="Click" Handler="DistanceSpeedButton_Click" />
                                 </Style>
                             </StackPanel.Resources>
@@ -1868,7 +1880,7 @@
 
                                 <!-- Length of blue path -->
                                 <StackPanel Orientation="Horizontal" Margin="0">
-                                    <Button Style="{StaticResource styleClearPathButton}" Tag="Blue" />
+                                    <Button Style="{StaticResource styleClearPathButton}" IsEnabled="{Binding BluePathVisible}" Tag="Blue" />
                                     <Line Style="{StaticResource styleSegmentIcon}" Stroke="Blue" />
                                     <TextBlock TextAlignment="Right" Width="50"
                                            Text="{Binding DistanceBluePath, StringFormat=N2, FallbackValue=1.11}" />
@@ -1876,12 +1888,13 @@
                                     <TextBlock TextAlignment="Right" Width="50"
                                            Text="{Binding DurationBluePath, StringFormat=N2, FallbackValue=1.11}" />
                                     <TextBlock Text="s" />
-                                    <Button Style="{StaticResource styleAddToPathButton}" Tag="Blue" />
+                                    <Button Style="{StaticResource styleMinusPathButton}" IsEnabled="{Binding BluePathVisible}" Tag="Blue" />
+                                    <Button Style="{StaticResource styleAddToPathButton}" IsEnabled="{Binding TempSegmentVisible}" Tag="Blue" />
                                 </StackPanel>
                                 
                                 <!-- Length of red path -->
                                 <StackPanel Orientation="Horizontal" Margin="0">
-                                    <Button Style="{StaticResource styleClearPathButton}" Tag="Red" />
+                                    <Button Style="{StaticResource styleClearPathButton}" IsEnabled="{Binding RedPathVisible}" Tag="Red" />
                                     <Line Style="{StaticResource styleSegmentIcon}" Stroke="Red" />
                                     <TextBlock TextAlignment="Right" Width="50"
                                            Text="{Binding DistanceRedPath, StringFormat=N2, FallbackValue=22.22}" />
@@ -1889,12 +1902,13 @@
                                     <TextBlock TextAlignment="Right" Width="50"
                                            Text="{Binding DurationRedPath, StringFormat=N2, FallbackValue=22.22}" />
                                     <TextBlock Text="s" />
-                                    <Button Style="{StaticResource styleAddToPathButton}" Tag="Red" />
+                                    <Button Style="{StaticResource styleMinusPathButton}" IsEnabled="{Binding RedPathVisible}" Tag="Red" />
+                                    <Button Style="{StaticResource styleAddToPathButton}" IsEnabled="{Binding TempSegmentVisible}" Tag="Red" />
                                 </StackPanel>
                                 
                                 <!-- Length of green path -->
                                 <StackPanel Orientation="Horizontal" Margin="0">
-                                    <Button Style="{StaticResource styleClearPathButton}" Tag="Green" />
+                                    <Button Style="{StaticResource styleClearPathButton}" IsEnabled="{Binding GreenPathVisible}" Tag="Green" />
                                     <Line Style="{StaticResource styleSegmentIcon}" Stroke="Green" />
                                     <TextBlock TextAlignment="Right" Width="50"
                                            Text="{Binding DistanceGreenPath, StringFormat=N2, FallbackValue=333.33}" />
@@ -1902,7 +1916,8 @@
                                     <TextBlock TextAlignment="Right" Width="50"
                                            Text="{Binding DurationGreenPath, StringFormat=N2, FallbackValue=333.33}" />
                                     <TextBlock Text="s" />
-                                    <Button Style="{StaticResource styleAddToPathButton}" Tag="Green" />
+                                    <Button Style="{StaticResource styleMinusPathButton}" IsEnabled="{Binding GreenPathVisible}" Tag="Green" />
+                                    <Button Style="{StaticResource styleAddToPathButton}" IsEnabled="{Binding TempSegmentVisible}" Tag="Green" />
                                 </StackPanel>
                             </StackPanel>
                         </Border>


### PR DESCRIPTION
Addressing issue #10.
- In-game distance can be calculated and displayed in both in-game units and the time it takes to travel that distance when running without buffs or with alacrity, hyper-alacrity, or force speed.
- Distance can calculated between double click points and the live Leader position.
- Distance can calculated as a single line segment or as a path of line segments. Up to three paths can be compared at the same time.